### PR TITLE
fix: Correct missing `mkdir` in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,6 +125,7 @@ pipeline {
       }
 
       steps {
+        sh 'mkdir -p .npm'
         sh "git checkout -b ${GIT_BRANCH} origin/${GIT_BRANCH}"
 
         versioner(


### PR DESCRIPTION
The previous release failed due to this mistake.  Correcting.