### PR TITLE
package: Fine-tune the .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,12 +2,9 @@
 npm-debug.log*
 coverage
 .nyc_output
-build/Release
-.node_repl_history
 *.tgz
 .env
-.next
 *.swp
 *.vim
-test/
 .npm
+Jenkinsfile


### PR DESCRIPTION
We *should* be including tests, especially since it has
100% coverage.  It should ignore Jenkinsfile, and a few
things were removed that don't seem to be true ignore
cases.

Semver: patch