### PR TITLE
feat!: drop max-len rule from 160 to 90

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package contains the `eslint` configuration that LogDNA prefers to use acro
 
 We do not use peer dependencies, so make sure that `eslint` is also installed as a dev dependency.
 
-```
+```shell
 npm install eslint-config-logdna eslint --save-dev
 ```
 
@@ -20,7 +20,7 @@ Once the package is installed, there are a few easy steps to get it executing wi
 
 It is best if `eslint` is configured as a script in `package.json` and hooked in as `pre` scripts where necessary.
 
-```
+```javascript
 "scripts": {
   "lint": "eslint .",
   "pretest": "npm run lint"
@@ -33,7 +33,7 @@ Add this configuration section to the `package.json` file of the target project.
 specific to the project that needs linting.  The `ignorePatterns` is only important for directories that may contain `.js`
 files since `eslint` will only lint javascript files by default.
 
-```
+```javascript
 "eslintConfig": {
   "extends": [
     "logdna"

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -84,7 +84,7 @@
       }
     }],
     "linebreak-style": ["error", "unix"],
-    "max-len": [2, 160, {
+    "max-len": [2, 90, {
       "ignoreComments": true
     }],
     "no-alert": 2,

--- a/test/failures.js
+++ b/test/failures.js
@@ -5,16 +5,29 @@ const fs = require('fs')
 const {test, threw} = require('tap')
 const {CLIEngine} = require('eslint')
 const EOL_CODE = path.join(__dirname, 'fixtures', 'no-eol-fixture')
+const MAX_LEN_CODE = path.join(__dirname, 'fixtures', 'max-len-fixture')
 
 const readFile = fs.promises.readFile
 test('invalid config', async (t) => {
-  const code = await readFile(EOL_CODE, 'utf8')
   const cli = new CLIEngine({
     useEslintrc: false
   , configFile: 'eslintrc.json'
   })
 
-  const result = cli.executeOnText(code)
-  t.equal(result.errorCount, 1, 'new line missing')
-  t.equal(result.results[0].messages[0].ruleId, 'eol-last', 'missing newline')
+  t.test('no-eol', async (t) => {
+    const code = await readFile(EOL_CODE, 'utf8')
+    const result = cli.executeOnText(code)
+    t.equal(result.errorCount, 1, 'error count')
+    t.equal(result.results[0].messages[0].ruleId, 'eol-last', 'missing newline')
+  })
+
+  t.test('max-len', async (t) => {
+    const code = await readFile(MAX_LEN_CODE, 'utf8')
+    const result = cli.executeOnText(code)
+    t.equal(result.errorCount, 1, 'error count')
+    const messages = result.results[0].messages
+
+    t.equal(messages[0].ruleId, 'max-len', 'max length exceeded')
+    t.match(messages[0].message, /maximum allowed is 90/ig, 'message expected line length')
+  })
 }).catch(threw)

--- a/test/fixture
+++ b/test/fixture
@@ -1,5 +1,6 @@
 'use strict'
 
+// This is a very very long comment that should probably be on multiple line. But comments are ignored so this will not cause an error when the linter actually runs
 const path = require('path')
 const fs = require('fs')
 const {promisify} = require('util')

--- a/test/fixtures/max-len-fixture
+++ b/test/fixtures/max-len-fixture
@@ -1,0 +1,7 @@
+'use strict'
+
+const BREAK_MAX_LEN = 'this is a very long string that will excced the maximum line length of 90'
+
+module.exports = {
+  BREAK_MAX_LEN
+}


### PR DESCRIPTION
This sets the maximum line length to 90 for lines of source code.
Currently, comments are ignored so those lines are an exception to the
rule.

Semver: major
Ref: LOG-7437