### PR TITLE
feat!: add eslint-plugin-logdna and associated config

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -16,7 +16,8 @@
   },
   "plugins": [
     "node",
-    "sensible"
+    "sensible",
+    "logdna"
   ],
   "rules": {
     "accessor-pairs": 0,
@@ -219,6 +220,22 @@
       "functionPrototypeMethods": false
     }],
     "yoda": 0,
-    "sensible/check-require": [2, "always"]
+    "sensible/check-require": [2, "always"],
+    "logdna/grouped-require": 2,
+    "logdna/require-file-extension": 2,
+    "logdna/tap-consistent-assertions": [2, {
+      "preferredMap": {
+        "error": "error",
+        "equal": "strictEqual",
+        "not": "notStrictEqual",
+        "same": "deepEqual",
+        "notSame": "notDeepEqual",
+        "strictSame": "strictDeepEqual",
+        "strictNotSame": "strictDeepNotEqual",
+        "match": "match",
+        "notMatch": "notMatch",
+        "type": "type"
+      }
+    }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "tap": "^14.10.7"
   },
   "dependencies": {
+    "eslint-plugin-logdna": "^1.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-sensible": "^2.1.0"
   }

--- a/test/failures.js
+++ b/test/failures.js
@@ -6,12 +6,14 @@ const {test, threw} = require('tap')
 const {CLIEngine} = require('eslint')
 const EOL_CODE = path.join(__dirname, 'fixtures', 'no-eol-fixture')
 const MAX_LEN_CODE = path.join(__dirname, 'fixtures', 'max-len-fixture')
+const LOGDNA_PLUGIN_CODE = path.join(__dirname, 'fixtures', 'logdna-plugin-fixture')
 
 const readFile = fs.promises.readFile
 test('invalid config', async (t) => {
   const cli = new CLIEngine({
     useEslintrc: false
-  , configFile: 'eslintrc.json'
+  , cwd: __dirname
+  , configFile: '../eslintrc.json'
   })
 
   t.test('no-eol', async (t) => {
@@ -29,5 +31,40 @@ test('invalid config', async (t) => {
 
     t.equal(messages[0].ruleId, 'max-len', 'max length exceeded')
     t.match(messages[0].message, /maximum allowed is 90/ig, 'message expected line length')
+  })
+
+  t.test('plugin-logdna', async (t) => {
+    const code = await readFile(LOGDNA_PLUGIN_CODE, 'utf8')
+    const result = cli.executeOnText(code)
+    t.equal(result.errorCount, 4, 'error count')
+    const messages = result.results[0].messages
+
+    t.equal(messages[0].ruleId, 'logdna/require-file-extension', 'file extension required')
+    t.equal(
+      messages[0].message
+      , 'Missing file extension for local module.'
+      , 'message expected file extension'
+    )
+
+    t.equal(messages[1].ruleId, 'logdna/grouped-require', 'require grouping')
+    t.equal(
+      messages[1].message
+      , 'Expected \'builtin\' require before \'local\' require.'
+      , 'message expected for grouped require'
+    )
+
+    t.equal(messages[2].ruleId, 'logdna/tap-consistent-assertions', 'consistent assertions')
+    t.equal(
+      messages[2].message
+      , 'The "strictEqual" alias is preferred over "isEqual"'
+      , 'message expected preferred alias'
+    )
+
+    t.equal(messages[3].ruleId, 'logdna/tap-consistent-assertions', 'consistent assertions')
+    t.equal(
+      messages[3].message
+      , 'The "deepEqual" alias is preferred over "same"'
+      , 'message expected preferred alias'
+    )
   })
 }).catch(threw)

--- a/test/fixtures/logdna-plugin-fixture
+++ b/test/fixtures/logdna-plugin-fixture
@@ -1,0 +1,10 @@
+'use strict'
+
+const test = require('./test/basic')
+const net = require('net')
+
+test('fake test', async (t) => {
+  t.ok(net.isIP('12.34.56.78'))
+  t.isEqual(1, 1, '1 === 1')
+  t.same(2 + 2, 5, '2 + 2 === 5')
+})


### PR DESCRIPTION
This adds eslint-plugin-logdna as a dependency, along with
standard configuration for the provided rules.

Semver: major