### PR TITLE
feat: allow unused rest siblings

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -169,7 +169,8 @@
     "no-unused-labels": 2,
     "no-unused-vars": [2, {
       "vars": "all",
-      "args": "none"
+      "args": "none",
+      "ignoreRestSiblings": true
     }],
     "no-use-before-define": [2, {
       "functions": false

--- a/test/fixture
+++ b/test/fixture
@@ -26,8 +26,9 @@ const isFoo = OPTIONS.FOO
   ? OPTIONS.BAR
   : OPTIONS.TEST
 
+const {TEST, BAR: notUsed, ...others} = OPTIONS
 function getOptions() {
-  return isFoo ? OPTIONS : null
+  return isFoo ? OPTIONS : others
 }
 
 function rand(bytes = 10, cb) {


### PR DESCRIPTION
A common pattern for immutably removing fields from an
object is using rest properties, picking out the fields you _dont_
want and collecting the remaining fields into a new object.

This expands the config for `no-unused-vars` to allow unused
variables only when the are siblings of a rest property in
a destructuring assignment.

Semver: minor
Ref: LOG-7154

---

Opted for this config over an explicit `varsIgnorePattern` - it seems strict enough for the vast majority of cases, without any weird scope situations. The alternative would be coming up with a special pattern (on top of `_`) that would be both obvious and strict enough.