### PR TITLE
chore(deps): eslint-plugin-sensible@2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   "dependencies": {
     "eslint-plugin-logdna": "^1.0.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-sensible": "^2.1.0"
+    "eslint-plugin-sensible": "^2.2.1"
   }
 }


### PR DESCRIPTION
Includes fixes for [check-require option handling](https://github.com/esatterwhite/eslint-plugin-sensible/commit/eec316e0741aad36f2b35d6c55d0c61047b75164).
This fix allows mono repos to accurately specify the root location of
the package.json file for the target project.

Semver: patch