### PR TITLE
feat(rules): enable rule to dis-allow debugger statements.

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,6 +1,7 @@
 esm: false
 ts: false
 jsx: false
+browser: false
 check-coverage: true
 100: true
 reporter: classic

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -94,6 +94,7 @@
     "no-case-declarations": 2,
     "no-cond-assign": [2, "except-parens"],
     "no-const-assign": "error",
+    "no-debugger": "error",
     "no-div-regex": 0,
     "no-else-return": 0,
     "no-empty-function": [2, {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/logdna/eslint-config-logdna#readme",
   "devDependencies": {
-    "eslint": "^7.9.0",
+    "eslint": "^7.19.0",
     "tap": "^14.10.7",
     "tap-xunit": "^2.4.1"
   },

--- a/test/failures.js
+++ b/test/failures.js
@@ -26,6 +26,12 @@ test('Invalid linting for larger code blocks read from fixtures', async (t) => {
     t.match(messages[0].message, /maximum allowed is 90/ig, 'message expected line length')
   })
 
+  t.test('no-debugger', async (t) => {
+    const result = cli.executeOnFiles(['no-debugger-fixture'])
+    t.equal(result.errorCount, 1, 'error count')
+    t.equal(result.results[0].messages[0].ruleId, 'no-debugger', 'missing newline')
+  })
+
   t.test('plugin-logdna', async (t) => {
     const result = cli.executeOnFiles(['logdna-plugin-fixture'])
     const messages = result.results[0].messages

--- a/test/fixtures/no-debugger-fixture
+++ b/test/fixtures/no-debugger-fixture
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = fooBar
+
+function fooBar() {
+  debugger
+  return true
+}


### PR DESCRIPTION
We previously would use a trailing semi-colon so the linter would find
these. Since we've enabled auto-fix for most rules, its possible for
semis to be removed leaving stray debugger statements in code.

This ensures the linter will fail if a debugger statement is left behind

Semver: minor