### PR TITLE
feat(package): enable ecmascript 2020

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -21,6 +21,17 @@
         "test",
         "maintenance"
       ]
+    },
+    {
+      "login": "darinspivey",
+      "name": "Darin Spivey",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1874788?v=4",
+      "profile": "https://github.com/darinspivey",
+      "contributions": [
+        "doc",
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,27 @@
+{
+  "projectName": "eslint-config-logdna",
+  "projectOwner": "logdna",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "esatterwhite",
+      "name": "Eric Satterwhite",
+      "avatar_url": "https://avatars.githubusercontent.com/u/148561?v=4",
+      "profile": "http://codedependant.net/",
+      "contributions": [
+        "doc",
+        "code",
+        "test",
+        "maintenance"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -32,6 +32,18 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "mdeltito",
+      "name": "Mike Del Tito",
+      "avatar_url": "https://avatars.githubusercontent.com/u/69520?v=4",
+      "profile": "https://github.com/mdeltito",
+      "contributions": [
+        "doc",
+        "code",
+        "test",
+        "maintenance"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,11 +9,17 @@
     "SharedArrayBuffer": "readonly"
   },
   "parserOptions": {
-    "ecmaVersion": 2019,
+    "ecmaVersion": 2020,
+    "sourceType": "script",
     "ecmaFeatures": {
       "globalReturn": true
     }
   },
+  "ignorePatterns": [
+    "node_modules/",
+    "coverage/",
+    ".nyc_output"
+  ],
   "plugins": [
     "node",
     "sensible",

--- a/.taprc
+++ b/.taprc
@@ -11,6 +11,8 @@ output-file: coverage/.tap-output
 coverage-report:
 - text
 - text-summary
+- json
+- json-summary
 - html
 files:
 - test/*.js

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,139 @@
+# Contributor's Code of Conduct
+
+If you contribute to this repo, you agree to abide by this code of conduct for
+this community.
+
+We abide by the
+[Contributor Covenant Code of Conduct, 2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
+It is reproduced below for ease of use.
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[opensource@logdna.com](mailto:opensource@logdna.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+## Process
+
+We use a fork-and-PR process, also known as a triangular workflow. This process
+is fairly common in open-source projects. Here's the basic workflow:
+
+1. Fork the upstream repo to create your own repo. This repo is called the origin repo.
+2. Clone the origin repo to create a working directory on your local machine.
+3. Work your changes on a branch in your working directory, then add, commit, and push your work to your origin repo.
+4. Submit your changes as a PR against the upstream repo. You can use the upstream repo UI to do this.
+5. Maintainers review your changes. If they ask for changes, you work on your
+   origin repo's branch and then submit another PR. Otherwise, if no changes are made,
+   then the branch with your PR is merged to upstream's main trunk, the main branch.
+
+When you work in a triangular workflow, you have the upstream repo, the origin
+repo, and then your working directory (the clone of the origin repo). You do
+a `git fetch` from upstream to local, push from local to origin, and then do a PR from origin to
+upstream&mdash;a triangle.
+
+If this workflow is too much to understand to start, that's ok! You can use
+GitHub's UI to make a change, which is autoset to do most of this process for
+you. We just want you to be aware of how the entire process works before
+proposing a change.
+
+Thank you for your contributions; we appreciate you!
+
+## License
+
+Note that we use a standard [MIT](./LICENSE) license on this repo.
+
+## Coding style
+
+Code style is enforced by [eslint][]. Linting is applied CI builds when a pull request
+is made. The rule set being enforced is provided by [eslint-config-logdna][]
+
+## Questions?
+
+The easiest way to get our attention is to comment on an existing, or open a new
+[issue][].
+
+[eslint]: https://eslint.org
+[eslint-config-logdna]: ./.eslint.json
+[issue]: https://github.com/logdna/eslint-config-logdna/issues
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `eslint-config-logdna`
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This package contains the `eslint` configuration that LogDNA prefers to use across all projects, public and private.
@@ -60,6 +60,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tr>
     <td align="center"><a href="http://codedependant.net/"><img src="https://avatars.githubusercontent.com/u/148561?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Eric Satterwhite</b></sub></a><br /><a href="https://github.com/logdna/eslint-config-logdna/commits?author=esatterwhite" title="Documentation">📖</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=esatterwhite" title="Code">💻</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=esatterwhite" title="Tests">⚠️</a> <a href="#maintenance-esatterwhite" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/darinspivey"><img src="https://avatars.githubusercontent.com/u/1874788?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Darin Spivey</b></sub></a><br /><a href="https://github.com/logdna/eslint-config-logdna/commits?author=darinspivey" title="Documentation">📖</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=darinspivey" title="Code">💻</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=darinspivey" title="Tests">⚠️</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `eslint-config-logdna`
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This package contains the `eslint` configuration that LogDNA prefers to use across all projects, public and private.
@@ -61,6 +61,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="http://codedependant.net/"><img src="https://avatars.githubusercontent.com/u/148561?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Eric Satterwhite</b></sub></a><br /><a href="https://github.com/logdna/eslint-config-logdna/commits?author=esatterwhite" title="Documentation">📖</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=esatterwhite" title="Code">💻</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=esatterwhite" title="Tests">⚠️</a> <a href="#maintenance-esatterwhite" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://github.com/darinspivey"><img src="https://avatars.githubusercontent.com/u/1874788?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Darin Spivey</b></sub></a><br /><a href="https://github.com/logdna/eslint-config-logdna/commits?author=darinspivey" title="Documentation">📖</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=darinspivey" title="Code">💻</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=darinspivey" title="Tests">⚠️</a></td>
+    <td align="center"><a href="https://github.com/mdeltito"><img src="https://avatars.githubusercontent.com/u/69520?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mike Del Tito</b></sub></a><br /><a href="https://github.com/logdna/eslint-config-logdna/commits?author=mdeltito" title="Documentation">📖</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=mdeltito" title="Code">💻</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=mdeltito" title="Tests">⚠️</a> <a href="#maintenance-mdeltito" title="Maintenance">🚧</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # `eslint-config-logdna`
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This package contains the `eslint` configuration that LogDNA prefers to use across all projects, public and private.
 
@@ -46,3 +49,23 @@ files since `eslint` will only lint javascript files by default.
   ]
 }
 ```
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="http://codedependant.net/"><img src="https://avatars.githubusercontent.com/u/148561?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Eric Satterwhite</b></sub></a><br /><a href="https://github.com/logdna/eslint-config-logdna/commits?author=esatterwhite" title="Documentation">📖</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=esatterwhite" title="Code">💻</a> <a href="https://github.com/logdna/eslint-config-logdna/commits?author=esatterwhite" title="Tests">⚠️</a> <a href="#maintenance-esatterwhite" title="Maintenance">🚧</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 'use strict'
 
-module.exports = require('./eslintrc.json')
+module.exports = require('./.eslintrc.json')

--- a/package.json
+++ b/package.json
@@ -3,22 +3,12 @@
   "version": "4.1.0",
   "description": "LogDNA's preferred eslint config to be used across all projects",
   "main": "index.js",
+  "private": false,
   "scripts": {
     "lint": "eslint ./",
     "pretest": "npm run lint",
     "test": "tools/test.sh"
   },
-  "eslintConfig": {
-    "root": true,
-    "ignorePatterns": [
-      "node_modules/",
-      "coverage/"
-    ],
-    "parserOptions": {
-      "ecmaVersion": 2019
-    }
-  },
-  "private": false,
   "publishConfig": {
     "access": "public"
   },
@@ -31,6 +21,9 @@
     "email": "help@logdna.com"
   },
   "license": "MIT",
+  "eslintConfig": {
+    "root": true
+  },
   "bugs": {
     "url": "https://github.com/logdna/eslint-config-logdna/issues"
   },

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const config = require('../index.js')
 const {test, threw} = require('tap')
+const config = require('../index.js')
 
 function isObject(obj) {
   return typeof obj === 'object' && obj !== null

--- a/test/config.js
+++ b/test/config.js
@@ -12,9 +12,9 @@ test('valid config', async (t) => {
   const code = await readFile(VALID_CODE, 'utf8')
   const cli = new CLIEngine({
     useEslintrc: false
-  , configFile: 'eslintrc.json'
+  , configFile: '.eslintrc.json'
   })
 
   const result = cli.executeOnText(code)
-  t.equal(result.errorCount, 0, 'error count')
+  t.strictEqual(result.errorCount, 0, 'error count')
 }).catch(threw)

--- a/test/failures.js
+++ b/test/failures.js
@@ -8,68 +8,88 @@ test('Invalid linting for larger code blocks read from fixtures', async (t) => {
   const cli = new CLIEngine({
     useEslintrc: false
   , cwd: path.join(__dirname, 'fixtures')
-  , configFile: '../../eslintrc.json'
+  , configFile: '../../.eslintrc.json'
   })
 
   t.test('no-eol', async (t) => {
     const result = cli.executeOnFiles(['no-eol-fixture'])
-    t.equal(result.errorCount, 1, 'error count')
-    t.equal(result.results[0].messages[0].ruleId, 'eol-last', 'missing newline')
+    t.strictEqual(result.errorCount, 1, 'error count')
+    t.strictEqual(result.results[0].messages[0].ruleId, 'eol-last', 'missing newline')
   })
 
   t.test('max-len', async (t) => {
     const result = cli.executeOnFiles(['max-len-fixture'])
-    t.equal(result.errorCount, 1, 'error count')
+    t.strictEqual(result.errorCount, 1, 'error count')
     const messages = result.results[0].messages
 
-    t.equal(messages[0].ruleId, 'max-len', 'max length exceeded')
-    t.match(messages[0].message, /maximum allowed is 90/ig, 'message expected line length')
+    t.strictEqual(messages[0].ruleId, 'max-len', 'max length exceeded')
+    t.match(
+      messages[0].message
+    , /maximum allowed is 90/ig
+    , 'message expected line length'
+    )
   })
 
   t.test('no-debugger', async (t) => {
     const result = cli.executeOnFiles(['no-debugger-fixture'])
-    t.equal(result.errorCount, 1, 'error count')
-    t.equal(result.results[0].messages[0].ruleId, 'no-debugger', 'missing newline')
+    t.strictEqual(result.errorCount, 1, 'error count')
+    t.strictEqual(result.results[0].messages[0].ruleId, 'no-debugger', 'missing newline')
   })
 
   t.test('plugin-logdna', async (t) => {
     const result = cli.executeOnFiles(['logdna-plugin-fixture'])
     const messages = result.results[0].messages
-    t.equal(result.errorCount, 5, 'error count')
+    t.strictEqual(result.errorCount, 5, 'error count')
 
-    t.equal(messages[0].ruleId, 'logdna/require-file-extension', 'file extension required')
-    t.equal(
+    t.strictEqual(
+      messages[0].ruleId
+    , 'logdna/require-file-extension'
+    , 'file extension required'
+    )
+    t.strictEqual(
       messages[0].message
-      , 'Missing file extension for local module.'
-      , 'message expected file extension'
+    , 'Missing file extension for local module.'
+    , 'message expected file extension'
     )
 
-    t.equal(messages[1].ruleId, 'sensible/check-require', 'required module is missing')
-    t.equal(
+    t.strictEqual(
+      messages[1].ruleId
+    , 'sensible/check-require'
+    , 'required module is missing'
+    )
+    t.strictEqual(
       messages[1].message
-      , 'Missing require: ./test/basic. Path does not exist'
-      , 'message expected for missing module'
+    , 'Missing require: ./test/basic. Path does not exist'
+    , 'message expected for missing module'
     )
 
-    t.equal(messages[2].ruleId, 'logdna/grouped-require', 'require grouping')
-    t.equal(
+    t.strictEqual(messages[2].ruleId, 'logdna/grouped-require', 'require grouping')
+    t.strictEqual(
       messages[2].message
-      , 'Expected \'builtin\' require before \'local\' require.'
-      , 'message expected for grouped require'
+    , 'Expected \'builtin\' require before \'local\' require.'
+    , 'message expected for grouped require'
     )
 
-    t.equal(messages[3].ruleId, 'logdna/tap-consistent-assertions', 'consistent assertions')
-    t.equal(
+    t.strictEqual(
+      messages[3].ruleId
+    , 'logdna/tap-consistent-assertions'
+    , 'consistent assertions'
+    )
+    t.strictEqual(
       messages[3].message
-      , 'The "strictEqual" alias is preferred over "isEqual"'
-      , 'message expected preferred alias'
+    , 'The "strictEqual" alias is preferred over "isEqual"'
+    , 'message expected preferred alias'
     )
 
-    t.equal(messages[4].ruleId, 'logdna/tap-consistent-assertions', 'consistent assertions')
-    t.equal(
+    t.strictEqual(
+      messages[4].ruleId
+    , 'logdna/tap-consistent-assertions'
+    , 'consistent assertions'
+    )
+    t.strictEqual(
       messages[4].message
-      , 'The "deepEqual" alias is preferred over "same"'
-      , 'message expected preferred alias'
+    , 'The "deepEqual" alias is preferred over "same"'
+    , 'message expected preferred alias'
     )
   })
 }).catch(threw)
@@ -78,7 +98,7 @@ test('Invlalid linting with quick-and-dirty inline code', async (t) => {
   const cli = new CLIEngine({
     useEslintrc: false
   , cwd: __dirname
-  , configFile: '../eslintrc.json'
+  , configFile: '../.eslintrc.json'
   , rules: {
       'strict': 'off'
     , 'sensible/indent': 'off'
@@ -91,11 +111,11 @@ test('Invlalid linting with quick-and-dirty inline code', async (t) => {
     const code = '[].map(thing => { return thing + 1 })'
 
     const result = cli.executeOnText(code)
-    t.equal(result.errorCount, 1, 'error count')
+    t.strictEqual(result.errorCount, 1, 'error count')
     const messages = result.results[0].messages
 
-    t.equal(messages[0].ruleId, 'arrow-parens', 'arrow-parens is the rule id')
-    t.equal(
+    t.strictEqual(messages[0].ruleId, 'arrow-parens', 'arrow-parens is the rule id')
+    t.strictEqual(
       messages[0].message
     , 'Expected parentheses around arrow function argument.'
     , 'Error message is correct'
@@ -106,11 +126,15 @@ test('Invlalid linting with quick-and-dirty inline code', async (t) => {
     const code = '[].map((thing) => thing + 1)'
 
     const result = cli.executeOnText(code)
-    t.equal(result.errorCount, 1, 'error count')
+    t.strictEqual(result.errorCount, 1, 'error count')
     const messages = result.results[0].messages
 
-    t.equal(messages[0].ruleId, 'arrow-body-style', 'arrow-body-style is the rule id')
-    t.equal(
+    t.strictEqual(
+      messages[0].ruleId
+    , 'arrow-body-style'
+    , 'arrow-body-style is the rule id'
+    )
+    t.strictEqual(
       messages[0].message
     , 'Expected block statement surrounding arrow body.'
     , 'Error message is correct'
@@ -121,11 +145,11 @@ test('Invlalid linting with quick-and-dirty inline code', async (t) => {
     const code = 'const NOOP = () => {}'
 
     const result = cli.executeOnText(code)
-    t.equal(result.errorCount, 1, 'error count')
+    t.strictEqual(result.errorCount, 1, 'error count')
     const messages = result.results[0].messages
 
-    t.equal(messages[0].ruleId, 'func-style', 'func-style is the rule id')
-    t.equal(
+    t.strictEqual(messages[0].ruleId, 'func-style', 'func-style is the rule id')
+    t.strictEqual(
       messages[0].message
     , 'Expected a function declaration.'
     , 'Error message is correct'


### PR DESCRIPTION
Update the supported ecmascript version to 2020, and set source type
to script. Additionally includes some default ignore patterns for
node_modules, coverage and .nyc_output. Additionally moves
`eslintrc.json` to `.eslintrc.json` so the lint rules can be used to
lint this package

Semver: minor

- - -

Includes guides for our code of conduct and contributing to the
projects. These are intended to set expectations for our contributors as
well as ourselves.

Semver: patch