### PR TITLE
feat(rules)!: switch to tap-no-deprecated-aliases rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -230,20 +230,7 @@
     "yoda": 0,
     "logdna/grouped-require": 2,
     "logdna/require-file-extension": 2,
-    "logdna/tap-consistent-assertions": [2, {
-      "preferredMap": {
-        "error": "error",
-        "equal": "strictEqual",
-        "not": "notStrictEqual",
-        "same": "deepEqual",
-        "notSame": "notDeepEqual",
-        "strictSame": "strictDeepEqual",
-        "strictNotSame": "strictDeepNotEqual",
-        "match": "match",
-        "notMatch": "notMatch",
-        "type": "type"
-      }
-    }],
+    "logdna/tap-no-deprecated-aliases": 2,
     "sensible/check-require": [2, "always"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint ./",
     "pretest": "npm run lint",
     "test": "tools/test.sh",
+    "tap": "tap",
     "release": "semantic-release",
     "release:dry": "npm run release -- --dry-run --no-ci --branches ${BRANCH_NAME:-main}"
   },
@@ -41,7 +42,7 @@
     "tap-xunit": "^2.4.1"
   },
   "dependencies": {
-    "eslint-plugin-logdna": "^1.0.0",
+    "eslint-plugin-logdna": "^2.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-sensible": "^2.3.1"
   }

--- a/test/config.js
+++ b/test/config.js
@@ -16,5 +16,5 @@ test('valid config', async (t) => {
   })
 
   const result = cli.executeOnText(code)
-  t.strictEqual(result.errorCount, 0, 'error count')
+  t.equal(result.errorCount, 0, 'error count')
 }).catch(threw)

--- a/test/failures.js
+++ b/test/failures.js
@@ -13,16 +13,16 @@ test('Invalid linting for larger code blocks read from fixtures', async (t) => {
 
   t.test('no-eol', async (t) => {
     const result = cli.executeOnFiles(['no-eol-fixture'])
-    t.strictEqual(result.errorCount, 1, 'error count')
-    t.strictEqual(result.results[0].messages[0].ruleId, 'eol-last', 'missing newline')
+    t.equal(result.errorCount, 1, 'error count')
+    t.equal(result.results[0].messages[0].ruleId, 'eol-last', 'missing newline')
   })
 
   t.test('max-len', async (t) => {
     const result = cli.executeOnFiles(['max-len-fixture'])
-    t.strictEqual(result.errorCount, 1, 'error count')
+    t.equal(result.errorCount, 1, 'error count')
     const messages = result.results[0].messages
 
-    t.strictEqual(messages[0].ruleId, 'max-len', 'max length exceeded')
+    t.equal(messages[0].ruleId, 'max-len', 'max length exceeded')
     t.match(
       messages[0].message
     , /maximum allowed is 90/ig
@@ -32,64 +32,75 @@ test('Invalid linting for larger code blocks read from fixtures', async (t) => {
 
   t.test('no-debugger', async (t) => {
     const result = cli.executeOnFiles(['no-debugger-fixture'])
-    t.strictEqual(result.errorCount, 1, 'error count')
-    t.strictEqual(result.results[0].messages[0].ruleId, 'no-debugger', 'missing newline')
+    t.equal(result.errorCount, 1, 'error count')
+    t.equal(result.results[0].messages[0].ruleId, 'no-debugger', 'missing newline')
   })
 
   t.test('plugin-logdna', async (t) => {
     const result = cli.executeOnFiles(['logdna-plugin-fixture'])
     const messages = result.results[0].messages
-    t.strictEqual(result.errorCount, 5, 'error count')
+    t.equal(result.errorCount, 6, 'error count')
 
-    t.strictEqual(
+    t.equal(
       messages[0].ruleId
     , 'logdna/require-file-extension'
     , 'file extension required'
     )
-    t.strictEqual(
+    t.equal(
       messages[0].message
     , 'Missing file extension for local module.'
     , 'message expected file extension'
     )
 
-    t.strictEqual(
+    t.equal(
       messages[1].ruleId
     , 'sensible/check-require'
     , 'required module is missing'
     )
-    t.strictEqual(
+    t.equal(
       messages[1].message
     , 'Missing require: ./test/basic. Path does not exist'
     , 'message expected for missing module'
     )
 
-    t.strictEqual(messages[2].ruleId, 'logdna/grouped-require', 'require grouping')
-    t.strictEqual(
+    t.equal(messages[2].ruleId, 'logdna/grouped-require', 'require grouping')
+    t.equal(
       messages[2].message
     , 'Expected \'builtin\' require before \'local\' require.'
     , 'message expected for grouped require'
     )
 
-    t.strictEqual(
+    t.equal(
       messages[3].ruleId
-    , 'logdna/tap-consistent-assertions'
-    , 'consistent assertions'
+    , 'logdna/tap-no-deprecated-aliases'
+    , 'no deprecated assertions'
     )
-    t.strictEqual(
+    t.equal(
       messages[3].message
-    , 'The "strictEqual" alias is preferred over "isEqual"'
-    , 'message expected preferred alias'
+    , 'The "isEqual" alias is deprecated in favor of "equal"'
+    , 'message expected non-deprecated method'
     )
 
-    t.strictEqual(
+    t.equal(
       messages[4].ruleId
-    , 'logdna/tap-consistent-assertions'
-    , 'consistent assertions'
+    , 'logdna/tap-no-deprecated-aliases'
+    , 'no deprecated assertions'
     )
-    t.strictEqual(
+    t.equal(
       messages[4].message
-    , 'The "deepEqual" alias is preferred over "same"'
-    , 'message expected preferred alias'
+    , 'The "deepEqual" alias is deprecated in favor of "same"'
+    , 'message expected non-deprecated method'
+    )
+
+    t.equal(
+      messages[5].ruleId
+    , 'logdna/tap-no-deprecated-aliases'
+    , 'no deprecated assertions'
+    )
+    t.equal(
+      messages[5].message
+    , 'The "tearDown" alias is deprecated in favor of "teardown"'
+    , 'message expected non-deprecated method'
     )
   })
 }).catch(threw)
@@ -111,11 +122,11 @@ test('Invlalid linting with quick-and-dirty inline code', async (t) => {
     const code = '[].map(thing => { return thing + 1 })'
 
     const result = cli.executeOnText(code)
-    t.strictEqual(result.errorCount, 1, 'error count')
+    t.equal(result.errorCount, 1, 'error count')
     const messages = result.results[0].messages
 
-    t.strictEqual(messages[0].ruleId, 'arrow-parens', 'arrow-parens is the rule id')
-    t.strictEqual(
+    t.equal(messages[0].ruleId, 'arrow-parens', 'arrow-parens is the rule id')
+    t.equal(
       messages[0].message
     , 'Expected parentheses around arrow function argument.'
     , 'Error message is correct'
@@ -126,15 +137,15 @@ test('Invlalid linting with quick-and-dirty inline code', async (t) => {
     const code = '[].map((thing) => thing + 1)'
 
     const result = cli.executeOnText(code)
-    t.strictEqual(result.errorCount, 1, 'error count')
+    t.equal(result.errorCount, 1, 'error count')
     const messages = result.results[0].messages
 
-    t.strictEqual(
+    t.equal(
       messages[0].ruleId
     , 'arrow-body-style'
     , 'arrow-body-style is the rule id'
     )
-    t.strictEqual(
+    t.equal(
       messages[0].message
     , 'Expected block statement surrounding arrow body.'
     , 'Error message is correct'
@@ -145,11 +156,11 @@ test('Invlalid linting with quick-and-dirty inline code', async (t) => {
     const code = 'const NOOP = () => {}'
 
     const result = cli.executeOnText(code)
-    t.strictEqual(result.errorCount, 1, 'error count')
+    t.equal(result.errorCount, 1, 'error count')
     const messages = result.results[0].messages
 
-    t.strictEqual(messages[0].ruleId, 'func-style', 'func-style is the rule id')
-    t.strictEqual(
+    t.equal(messages[0].ruleId, 'func-style', 'func-style is the rule id')
+    t.equal(
       messages[0].message
     , 'Expected a function declaration.'
     , 'Error message is correct'

--- a/test/fixtures/logdna-plugin-fixture
+++ b/test/fixtures/logdna-plugin-fixture
@@ -6,5 +6,9 @@ const net = require('net')
 test('fake test', async (t) => {
   t.ok(net.isIP('12.34.56.78'))
   t.isEqual(1, 1, '1 === 1')
-  t.same(2 + 2, 5, '2 + 2 === 5')
+  t.deepEqual(2 + 2, 5, '2 + 2 === 5')
+
+  t.tearDown(() => {
+    return true
+  })
 })


### PR DESCRIPTION
BREAKING CHANGE: Un-aliased tap assertion methods will now be enforced

tap@15.0.0 deprecated the use of aliases for assertion methods, which
invalidates the concept of a "preferred" alias. This switches over to
a new rule for requiring the use of un-aliased assertion methods.

This rule is auto-fixable, and the changes it enforces are backwards
compatible with older versions of tap.

Ref: LOG-9396