### PR TITLE
feat(rules): consistent func param newlines

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,8 @@
     "eol-last": [2, "always"],
     "eqeqeq": [2, "allow-null"],
     "func-style": ["error", "declaration"],
+    "function-call-argument-newline": ["error", "consistent"],
+    "function-paren-newline": ["error", "multiline-arguments"],
     "handle-callback-err": [2, "^(error|err|er)"],
     "guard-for-in": 2,
     "indent": 0,

--- a/test/failures.js
+++ b/test/failures.js
@@ -116,9 +116,51 @@ test('Invalid linting for larger code blocks read from fixtures', async (t) => {
     , 'message expected non-deprecated method'
     )
   })
+
+  t.test('function-call-argument-newline', async (t) => {
+    const [result] = await linter.lintFiles(['function-call-argument-newline-fixture'])
+    const messages = result.messages
+    t.equal(result.errorCount, 3, 'error count')
+
+    t.equal(
+      messages[0].message
+    , 'Expected newline after \'(\'.'
+    , 'fooBar call 1: first param should be on separate line from function'
+    )
+
+    t.equal(
+      messages[1].message
+    , 'Expected newline between arguments/params.'
+    , 'fooBar call 2: second param should be followed by newline'
+    )
+
+    t.equal(
+      messages[2].message
+    , 'There should be a line break after this argument.'
+    , 'fooBar call 2: space after second param should be newline'
+    )
+  })
+
+  t.test('function-paren-newline', async (t) => {
+    const [result] = await linter.lintFiles(['function-paren-newline-fixture'])
+    const messages = result.messages
+    t.equal(result.errorCount, 2, 'error count')
+
+    t.equal(
+      messages[0].message
+    , 'Expected newline after \'(\'.'
+    , 'fooBar definition: first param should be on new line'
+    )
+
+    t.equal(
+      messages[1].message
+    , 'Expected newline between arguments/params.'
+    , 'twoBar definition: all params should be on own lines'
+    )
+  })
 }).catch(threw)
 
-test('Invlalid linting with quick-and-dirty inline code', async (t) => {
+test('Invalid linting with quick-and-dirty inline code', async (t) => {
   const linter = new ESLint({
     useEslintrc: false
   , cwd: __dirname

--- a/test/fixtures/function-call-argument-newline-fixture
+++ b/test/fixtures/function-call-argument-newline-fixture
@@ -1,0 +1,17 @@
+'use strict'
+
+module.exports = fooBar
+
+function fooBar(a, b, c) {
+  return true
+}
+
+fooBar('asdf',
+'ghjk'
+, 'asdfghjk'
+)
+
+fooBar(
+  'asdfasdf',
+  'asdf', 'asdf'
+)

--- a/test/fixtures/function-paren-newline-fixture
+++ b/test/fixtures/function-paren-newline-fixture
@@ -1,0 +1,29 @@
+'use strict'
+
+module.exports = fooBar
+
+function fooBar(a
+, b
+, c
+) {
+  return true
+}
+
+fooBar(
+  'asdf'
+, 'ghjk'
+, 'asdfghjk'
+)
+
+function twoBar(
+  a
+, b, c
+) {
+  return true
+}
+
+twoBar(
+  'asdf'
+, 'ghjk'
+, 'asdfghjk'
+)

--- a/test/fixtures/valid-code
+++ b/test/fixtures/valid-code
@@ -64,6 +64,33 @@ function plugin(opts) {
   }
 }
 
+function useLotsOfParameters(
+  a
+, b
+, c
+) {
+  console.log(a)
+  console.log(b)
+  console.log(c)
+}
+
+useLotsOfParameters(
+  'here is some text'
+, 'and some more text'
+, 'and a third param of text'
+)
+
+useLotsOfParameters('this is', 'also valid', 'param usage')
+
+useLotsOfParameters('a', 'b', {
+  a: 'a'
+, b: 'b'
+})
+
+useLotsOfParameters('a', 'b', (c) => {
+  console.log(c)
+})
+
 const someArray = [1, 2, 3]
 console.log(someArray.map((a) => { return a + 1 }))
 


### PR DESCRIPTION
Enforces having function parameters either all on one line or all on
their own lines. Applies both to defining and calling functions.

----

See: 
[function-call-argument-newline](https://eslint.org/docs/rules/function-call-argument-newline#options)
[function-paren-newline](https://eslint.org/docs/rules/function-paren-newline#options)