### PR TITLE
fix(no-unused-vars)!: enforce rule for unused arguments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -179,7 +179,7 @@
     "no-unused-labels": 2,
     "no-unused-vars": [2, {
       "vars": "all",
-      "args": "none",
+      "args": "after-used",
       "ignoreRestSiblings": true
     }],
     "no-use-before-define": [2, {

--- a/test/config.js
+++ b/test/config.js
@@ -17,4 +17,11 @@ test('valid config', async (t) => {
 
   const [result] = await linter.lintText(code)
   t.equal(result.errorCount, 0, 'error count')
+  // provide more context for failures by emitting a separate `fail`
+  // for each unexpected linting error
+  if (result.messages.length) {
+    for (const {message} of result.messages) {
+      t.fail(message)
+    }
+  }
 }).catch(threw)

--- a/test/failures.js
+++ b/test/failures.js
@@ -30,7 +30,31 @@ test('Invalid linting for larger code blocks read from fixtures', async (t) => {
     )
   })
 
-  t.test('no-multlintFilesiple-empty-lines', async (t) => {
+  t.test('no-unused-vars for arguments', async (t) => {
+    const [result] = await linter.lintFiles(['no-unused-args-fixture'])
+    t.equal(result.errorCount, 2, 'error count')
+
+    const messages = result.messages
+    t.ok(
+      messages.every(({ruleId}) => {
+        return ruleId === 'no-unused-vars'
+      })
+    , 'errors from expected rule'
+    )
+
+    t.match(
+      messages[0].message
+    , "'c' is defined but never used."
+    , 'message expected for unused after-used'
+    )
+    t.match(
+      messages[1].message
+    , "'r' is defined but never used."
+    , 'message expected for unused'
+    )
+  })
+
+  t.test('no-multiple-empty-lines', async (t) => {
     const [result] = await linter.lintFiles(['no-multiple-empty-lines-fixture'])
     t.equal(result.errorCount, 1, 'error count')
     const messages = result.messages
@@ -49,7 +73,7 @@ test('Invalid linting for larger code blocks read from fixtures', async (t) => {
     t.equal(result.messages[0].ruleId, 'no-debugger', 'missing newline')
   })
 
-  t.test('pluglintFilesin-logdna', async (t) => {
+  t.test('plugin-logdna', async (t) => {
     const [result] = await linter.lintFiles(['logdna-plugin-fixture'])
     const messages = result.messages
     t.equal(result.errorCount, 6, 'error count')

--- a/test/fixtures/function-call-argument-newline-fixture
+++ b/test/fixtures/function-call-argument-newline-fixture
@@ -3,7 +3,7 @@
 module.exports = fooBar
 
 function fooBar(a, b, c) {
-  return true
+  return b + c
 }
 
 fooBar('asdf',

--- a/test/fixtures/function-paren-newline-fixture
+++ b/test/fixtures/function-paren-newline-fixture
@@ -6,7 +6,7 @@ function fooBar(a
 , b
 , c
 ) {
-  return true
+  return b + c
 }
 
 fooBar(
@@ -19,7 +19,7 @@ function twoBar(
   a
 , b, c
 ) {
-  return true
+  return c
 }
 
 twoBar(

--- a/test/fixtures/no-unused-args-fixture
+++ b/test/fixtures/no-unused-args-fixture
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = fooBar
+
+function fooBar(a, b, c) {
+  return a + b + baz('test')
+}
+
+function baz(r) {
+  return true
+}

--- a/test/fixtures/valid-code
+++ b/test/fixtures/valid-code
@@ -56,7 +56,7 @@ async function doWork(opts) {
   console.log('ready', 11 + 33)
 })()
 
-function plugin(opts) {
+function plugin() {
   if (this.is_new) {
     this.id = Date.now()
   } else {


### PR DESCRIPTION
Previously we allowed unused arguments entirely, which can be a footgun (particularly in Tap tests with `t`). This enforces the `no-unused-vars` rule for arguments too, allowing unused arguments as long as later args _are_ used.

BREAKING CHANGES: all named arguments and all positional arguments
_after the last used argument_ will now be checked.

Closes: #26