### PR TITLE
chore(rules): update max length rule to ignore urls and template strings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -94,7 +94,9 @@
     }],
     "linebreak-style": ["error", "unix"],
     "max-len": [2, 90, {
-      "ignoreComments": true
+      "ignoreComments": true,
+      "ignoreUrls": true,
+      "ignoreTemplateLiterals": true
     }],
     "no-alert": 2,
     "no-async-promise-executor": [2],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -182,7 +182,8 @@
     "no-unused-vars": [2, {
       "vars": "all",
       "args": "after-used",
-      "ignoreRestSiblings": true
+      "ignoreRestSiblings": true,
+      "varsIgnorePattern": "^_$"
     }],
     "no-use-before-define": [2, {
       "functions": false

--- a/test/fixtures/valid-code
+++ b/test/fixtures/valid-code
@@ -72,6 +72,8 @@ function useLotsOfParameters(
   console.log(a)
   console.log(b)
   console.log(c)
+  const [value, _] = c.split(' ')
+  console.log(value)
 }
 
 useLotsOfParameters(


### PR DESCRIPTION
Multi line template strings and urls tend to be harder to read than the single line variant. URLs and template strings can be rather long and cumbersome to deal with across lines. This updates the max length rule to ignore urls and template literals